### PR TITLE
fix drawpd linux executable filename

### DIFF
--- a/pypsbuilder/psbuilder.py
+++ b/pypsbuilder/psbuilder.py
@@ -281,7 +281,7 @@ class PSBuilder(QtWidgets.QMainWindow, Ui_PSBuilder):
                 drpat = 'dr1*.exe'
             elif sys.platform.startswith('linux'):
                 tcpat = 'tc3*L'
-                drpat = 'dr1*L'
+                drpat = 'dr*L'
             else:
                 tcpat = 'tc3*'
                 drpat = 'dr1*'


### PR DESCRIPTION
drawpdL is the filename for the executable in linux in drawpd 115
-rwx------  2.1 unx   333052 bX defN 09-Oct-29 19:04 drawpd115-linux/drawpdL